### PR TITLE
Initial support for symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     }
   ],
   "require": {
-    "symfony/console": "~3.0|~2.7",
-    "symfony/yaml": "~3.0|~2.1"
+    "symfony/console": "~4.0|~3.0|~2.7",
+    "symfony/yaml": "~4.0|~3.0|~2.1"
   },
   "autoload": {
     "psr-4": { "Staempfli\\UniversalGenerator\\": "src/Staempfli/UniversalGenerator/" }


### PR DESCRIPTION
I did a manual test via composer using below global `composer.json`:

```
{
    "require": {
        "staempfli/magento2-code-generator": "^1.10",
	"staempfli/universal-code-generator": "dev-symfony4 as 1.2.x-dev",
	"symfony/console": "~4.1"
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/piotrkwiecinski/universal-code-generator.git"
        }
    ]
}
```

```
Package operations: 10 installs, 0 updates, 0 removals
  - Installing composer/ca-bundle (1.1.4): Loading from cache
  - Installing padraic/humbug_get_contents (1.1.2): Loading from cache
  - Installing symfony/polyfill-ctype (v1.10.0): Loading from cache
  - Installing symfony/yaml (v4.2.3): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.10.0): Loading from cache
  - Installing symfony/contracts (v1.0.2): Loading from cache
  - Installing symfony/console (v4.2.3): Loading from cache
  - Installing staempfli/universal-code-generator (dev-symfony4 df680e2): Cloning df680e2c0b from cache
  - Installing padraic/phar-updater (v1.0.6): Loading from cache
  - Installing staempfli/magento2-code-generator (1.11.0): Loading from cache
```

Generator launched as expected and commands seam to load.

@jalogut @mhauri

Refs: https://github.com/staempfli/magento2-code-generator/issues/21
Refs: https://github.com/staempfli/universal-code-generator/issues/1